### PR TITLE
Update version in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
     "dist/Leaflet.Modal.js",
     "dist/leaflet.modal.css"
   ],
-  "version": "0.0.2",
+  "version": "0.1.3",
   "authors": [
     "w8r <info@w8r.name>"
   ],


### PR DESCRIPTION
`bower install` complains that the version declared in the json (0.0.2) is different than the resolved one (0.1.3)